### PR TITLE
Fix for uploading to directories with conflicting files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: osfr
 Title: Interface to the 'Open Science Framework' ('OSF')
-Version: 0.2.8.9000
+Version: 0.2.8.9001
 Authors@R: c(
     person("Aaron", "Wolen",, "aaron@wolen.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2542-2202")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * tibble v3.0.0 is now the minimum required version
 
+## Fixes
+
+* Fixed bug preventing uploads directly to OSF directories that contained conflicting files (#121, #129)
+
 # osfr 0.2.8
 
 * Initial CRAN release

--- a/R/osf_upload.R
+++ b/R/osf_upload.R
@@ -150,6 +150,15 @@ osf_upload.osf_tbl_file <-
   # inventory of files to upload and/or remote directories to create
   manifest <- map_rbind(.upload_manifest, path = path, recurse = recurse)
 
+  # if uploading to a directory we need to update the remote paths for files
+  if (inherits(dest, "osf_tbl_file")) {
+    manifest$remote_path <- ifelse(
+      manifest$type == "file",
+      file.path(dest$name, manifest$remote_path),
+      manifest$remote_path
+    )
+  }
+
   # retrieve remote destinations
   manifest <- .ulm_add_remote_dests(manifest, dest, verbose)
 

--- a/tests/testthat/test-uploading.R
+++ b/tests/testthat/test-uploading.R
@@ -83,7 +83,7 @@ test_that("conflicting files can be skipped when uploading to a dir", {
   expect_s3_class(f2, "osf_tbl_file")
 })
 
-test_that("conflicting files can be skipped when uploading to a dir", {
+test_that("conflicting files can be overwritten when uploading to a dir", {
   skip_if_no_pat()
   writeLines("Lorem ipsum dolor sit amet, consectetur, ea trio posse", infile)
   expect_silent(


### PR DESCRIPTION
This is a fix for #121.

We were failing to match local files with their remote counterparts when the destination was a directory because remote paths for files included the directory name (e.g., `dir/file.txt`) but we were passing paths relative to the target directory (i.e., `./file.txt`).

I've tested a few different scenarios and the patch seems to hold but would appreciate some additional testing. @mnoetel, @timriffe, @cimentadaj, @befriendabacterium, let me know if get a chance to give it a spin.