### PR TITLE
fix pkgdown build

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -11,7 +11,7 @@ authors:
 
 navbar:
   structure:
-    left:  []
+    left:  
     right: [home, reference, articles, github]
 
 reference:


### PR DESCRIPTION
Using the same fix as @jeroen in https://github.com/ropensci-org/rotemplate/commit/3ac30a939a3aab97c3ca78c7e1d4672952b6ef45

Related pkgdown issue https://github.com/r-lib/pkgdown/issues/2070