### PR TITLE
Change .wb_download to use WB path ID

### DIFF
--- a/R/utils-accessors.R
+++ b/R/utils-accessors.R
@@ -6,7 +6,6 @@
 #' @examples
 #' me <- osf_retrieve_user("me")
 #' get_meta(me, "attributes", "full_name")
-#'
 #' @noRd
 get_meta <- function(x, ...) {
   stopifnot(inherits(x, "osf_tbl"))
@@ -55,3 +54,16 @@ get_remote_path <- function(x) {
   sub("^\\/", "", get_path(x))
 }
 
+#' Path for waterbutler API calls
+#'
+#' @noRd
+get_waterbutler_path_id <- function(x) {
+  stopifnot(inherits(x, c("osf_tbl_file", "osf_tbl_node")))
+
+  get_wb_path <- switch(class(x)[1],
+    osf_tbl_file = function(x) get_meta(x, "attributes", "path"),
+    osf_tbl_node = function(x) rep(".", nrow(x))
+  )
+
+  sub("^\\/", "", get_wb_path(x))
+}

--- a/R/utils-wb-files.R
+++ b/R/utils-wb-files.R
@@ -13,3 +13,21 @@ wb2osf <- function(x) {
   id <- strsplit(wb_path, split = "/", fixed = TRUE)[[1]][2]
   osf_retrieve_file(id)
 }
+
+#' Convert OSF entity to waterbutler path ID
+#'
+#' Discovered around 2022-03, OSF no longer accepts downloads with
+#' the GUID. The Waterbutler path ID is now necessary to download
+#' files.
+#'
+#' @param x An `osf_tbl` object
+#'
+#' @noRd
+as_wb_id <- function(x, ...) {
+  UseMethod("as_wb_id", x)
+}
+
+#' @export
+as_wb_id.osf_tbl <- function(x, ...) {
+  get_waterbutler_path_id(x)
+}


### PR DESCRIPTION
Around March 2022, I discovered that the OSF API no longer accepts GUIDs for downloading files. Instead, the Waterbutler path must be used. This PR just swaps the `fid` parameter in `.wb_download()` to use `as_wb_id()`, a new generic that mirrors the `as_id()` pattern but instead uses `get_meta(x, "attributes", "path")`.