### PR TITLE
Fix pkgdown configuration 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: osfr
 Title: Interface to the 'Open Science Framework' ('OSF')
-Version: 0.2.8.9002
+Version: 0.2.8.9003
 Authors@R: c(
     person("Aaron", "Wolen",, "aaron@wolen.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2542-2202")),
@@ -16,7 +16,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-1642-628X")),
     person("Heidi", "Seibold",, "heidi.seibold@stat.uni-muenchen.de", role = "rev")
     )
-Description: An interface for interacting with 'OSF' (<https://osf.io>). 'osfr' 
+Description: An interface for interacting with 'OSF' (<https://osf.io>). 'osfr'
     enables you to access open research materials and data, or create and
     manage your own private or public projects.
 Depends: R (>= 3.1.0)

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ test:
 doc: README.md vignettes
 	Rscript -e "devtools::document()"
 
+build-pkgdown:
+	R -e "pkgdown::build_site()"
+
 README.md: README.Rmd
 	Rscript -e "devtools::build_readme()"
 	rm README.html

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 ## Fixes
 
 * Fixed bug preventing uploads directly to OSF directories that contained conflicting files (#121, #129)
+* Fixed pkgdown site build (#147)
 
 ## Build and test infrastructure
 

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -11,10 +11,14 @@ authors:
 
 navbar:
   structure:
-    left:  
+    left:
     right: [home, reference, articles, github]
 
 reference:
+
+- title: Help
+  contents:
+  - '`osfr-package`'
 
 - title: Retrieving information from OSF
   desc: ~
@@ -31,6 +35,7 @@ reference:
   - '`osf_create`'
   - '`osf_mkdir`'
   - '`osf_mv`'
+  - '`osf_cp`'
   - '`osf_rm`'
   - '`osf_upload`'
 


### PR DESCRIPTION
Added two missing topics to `_pkgdown.yml`. Thanks to @maelle for reporting in #144!

Details:
- Added `osf_cp` and `osfr-package` topics to pkgdown
- Added `build-pkgdown` target to Makefile

Note: CI is failing because OSF's test server is [currently down](https://status.cos.io)
